### PR TITLE
FEA Add Endpoint to retrieve Pokemon by ID

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -30,6 +30,7 @@ package main
 import (
 	"fmt"
 	"pokemonb2w/internal/control"
+	"pokemonb2w/internal/facade"
 	"pokemonb2w/internal/middleware"
 
 	"log"
@@ -64,6 +65,7 @@ func getAPIRouter() *mux.Router {
 func setUpRoutes(apiRouter *mux.Router) {
 	control.AddAppInfoRoute(apiRouter)
 	control.AddHealthRoutes(apiRouter)
+	control.AddPokemonRoutes(apiRouter)
 }
 
 // Sets up middlewares in the API router
@@ -110,6 +112,10 @@ func serveSwagger() {
 	)
 }
 
+func startServices() {
+	facade.StartPokeAPIService()
+}
+
 // APP's entrypoint
 func main() {
 	// Load config variables
@@ -126,6 +132,9 @@ func main() {
 
 	// Serve Swagger UI
 	serveSwagger()
+
+	// Start services
+	startServices()
 
 	// $PORT is defined in the server
 	port := viper.Get("port")

--- a/internal/config.yml
+++ b/internal/config.yml
@@ -12,3 +12,5 @@ app:
     herokuAppNameVar: HEROKU_APP_NAME
     herokuBuildVar: HEROKU_RELEASE_VERSION
     herokuCreatedAtVar: HEROKU_RELEASE_CREATED_AT
+  pokeApi:
+    basePath: https://pokeapi.co/api/v2

--- a/internal/control/const.go
+++ b/internal/control/const.go
@@ -3,4 +3,6 @@ package control
 const (
 	healthPath  = "/health"
 	apiInfoPath = "/app-info"
+
+	pokemonByIDPath = "/pokemon/{id}"
 )

--- a/internal/control/pokemon.go
+++ b/internal/control/pokemon.go
@@ -1,0 +1,64 @@
+package control
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"pokemonb2w/internal/facade"
+	"pokemonb2w/internal/model"
+	"strconv"
+
+	"github.com/gorilla/mux"
+)
+
+// PokemonResponse response model
+//
+// This is used for returning a response with a pokemon inside the body
+//
+// swagger:response pokemonResponse
+type PokemonResponse struct {
+	// in: body
+	Pokemon *model.Pokemon `json:"pokemon"`
+}
+
+// GetPokemonParams params for retrieving pokemon by ID.
+//
+// This is used for retrieving pokemon by ID.
+//
+// swagger:parameters getPokemon
+type GetPokemonParams struct {
+	// in: path
+	// required: true
+	ID int `json:"id"`
+}
+
+// swagger:operation GET /pokemon/{id} pokemon getPokemon
+// ---
+// summary: Retrieves a pokemon by id.
+// description: Retrieves details about a pokemon by its id.
+// responses:
+//   '200':
+//     "$ref": "#/responses/pokemonResponse"
+//   '204':
+//     description: No pokemon found.
+//     schema:
+//       type: string
+func getPokemon(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	pokeID, err := strconv.Atoi(vars["id"])
+	if err != nil {
+		log.Panic(model.NewrequestError("Bad ID param type.", model.ErrorBadRequest))
+	}
+
+	pokemon := facade.GetPokemon(pokeID)
+	w.Header().Set("Content-Type", "application/json")
+	err = json.NewEncoder(w).Encode(pokemon)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// AddPokemonRoutes Adds all routes from pokemon controller to the router.
+func AddPokemonRoutes(r *mux.Router) {
+	r.HandleFunc(pokemonByIDPath, getPokemon).Methods(http.MethodGet, http.MethodOptions)
+}

--- a/internal/facade/pokemon.go
+++ b/internal/facade/pokemon.go
@@ -1,0 +1,193 @@
+package facade
+
+import (
+	"pokemonb2w/internal/model"
+	"pokemonb2w/internal/services"
+)
+
+var pokeAPIService services.PokeAPIRequester
+
+// StartPokeAPIService starts singleton for pokeAPI service
+func StartPokeAPIService() {
+	if pokeAPIService == nil {
+		pokeAPIService = services.NewPokeAPIRequester()
+	}
+}
+
+// GetPokemon ...
+func GetPokemon(id int) *model.Pokemon {
+	pokemonPokeAPIResponse := pokeAPIService.GetPokemon(id)
+
+	pokemon := &model.Pokemon{
+		ID:                     pokemonPokeAPIResponse.ID,
+		Name:                   pokemonPokeAPIResponse.Name,
+		Weight:                 pokemonPokeAPIResponse.Weight,
+		Height:                 pokemonPokeAPIResponse.Height,
+		Types:                  retrieveTypes(pokemonPokeAPIResponse),
+		LocationAreaEncounters: retrieveLocationAreas(pokemonPokeAPIResponse),
+		EvolutionChains:        retrieveEvoChains(pokemonPokeAPIResponse),
+		Image:                  retrieveImage(pokemonPokeAPIResponse),
+		BaseStats:              retrieveBaseStats(pokemonPokeAPIResponse),
+	}
+
+	return pokemon
+}
+
+func retrieveTypes(response *model.PokeAPIPokemonResponse) []string {
+	var types []string
+
+	for _, v := range response.Types {
+		types = append(types, v.Type.Name)
+	}
+
+	return types
+}
+
+func retrieveLocationAreas(response *model.PokeAPIPokemonResponse) []string {
+	var locations []string
+
+	locationAreaRes := pokeAPIService.GetAreaEncountersByURL(response.LocationAreaEncountersURL)
+	for _, v := range locationAreaRes.Locations {
+		locations = append(locations, v.LocationArea.Name)
+	}
+
+	return locations
+}
+
+func retrieveEvoChains(response *model.PokeAPIPokemonResponse) [][]string {
+	evoChains := make([][]string, 0)
+
+	speciesRes := pokeAPIService.GetPokemonSpeciesByURL(response.Species.URL)
+	evoChainsRes := pokeAPIService.GetEvolutionChainsByURL(speciesRes.EvolutionChain.URL)
+
+	startingChain := make([]string, 0)
+	evoChains = *fillEvoChainsRec(&evoChains, &startingChain, evoChainsRes.Chain)
+
+	return evoChains
+}
+
+func fillEvoChainsRec(allPaths *[][]string, current *[]string, chain model.PokeAPIChain) *[][]string {
+	if len(chain.EvolvesTo) == 0 {
+		*current = append(*current, chain.Species.Name)
+		*allPaths = append(*allPaths, *current)
+
+		return allPaths
+	}
+
+	*current = append(*current, chain.Species.Name)
+	for _, v := range chain.EvolvesTo {
+		var newPath []string
+		for _, p := range *current {
+			newPath = append(newPath, p)
+		}
+		allPaths = fillEvoChainsRec(allPaths, &newPath, v)
+	}
+
+	return allPaths
+}
+
+func retrieveImage(response *model.PokeAPIPokemonResponse) string {
+	image := response.Sprites.Versions.GenerationVIII.SwordShield.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationVII.UltraSunUltraMoon.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationVI.OmegaRubyAlphaSapphire.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationVI.XY.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationV.BlackWhite.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationIV.HeartGoldSoulSilver.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationIV.Platinum.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationIV.DiamondPearl.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationIII.FireRedLeafGreen.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationIII.Emerald.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationIII.RubySapphire.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationII.Crystal.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationII.Gold.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationII.Silver.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationI.Yellow.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	image = response.Sprites.Versions.GenerationI.RedBlue.FrontDefault
+	if image != "" {
+		return image
+	}
+
+	return "no_image_retrieved"
+}
+
+func retrieveBaseStats(response *model.PokeAPIPokemonResponse) *model.PokemonBaseStats {
+	var baseStats model.PokemonBaseStats
+
+	for _, v := range response.Stats {
+		if v.Stat.Name == "hp" {
+			baseStats.HP = v.BaseStat
+		} else if v.Stat.Name == "attack" {
+			baseStats.Attack = v.BaseStat
+		} else if v.Stat.Name == "defense" {
+			baseStats.Defense = v.BaseStat
+		} else if v.Stat.Name == "special-attack" {
+			baseStats.SpecialAttack = v.BaseStat
+		} else if v.Stat.Name == "special-defense" {
+			baseStats.SpecialDefense = v.BaseStat
+		} else if v.Stat.Name == "speed" {
+			baseStats.Speed = v.BaseStat
+		}
+	}
+
+	return &baseStats
+}

--- a/internal/model/pokemon.go
+++ b/internal/model/pokemon.go
@@ -1,0 +1,165 @@
+package model
+
+// Pokemon it's a model that describes a Pokemon.
+type Pokemon struct {
+	ID                     int              `json:"ID"`
+	Name                   string           `json:"name"`
+	Image                  string           `json:"image"`
+	Types                  []string         `json:"types"`
+	LocationAreaEncounters []string         `json:"locationAreaEncounters"`
+	EvolutionChains        [][]string       `json:"evolutionChains"`
+	Weight                 int              `json:"weight"`
+	Height                 int              `json:"height"`
+	BaseStats              PokemonBaseStats `json:"baseStats"`
+}
+
+// PokemonBaseStats is a model that describes a Pokemon's base stats.
+type PokemonBaseStats struct {
+	Speed          int `json:"speed"`
+	HP             int `json:"hp"`
+	Attack         int `json:"attack"`
+	Defense        int `json:"defense"`
+	SpecialAttack  int `json:"special-attack"`
+	SpecialDefense int `json:"special-defense"`
+}
+
+// PokeAPIPokemonResponse describes the response obtained from PokeAPI for a Pokemon
+type PokeAPIPokemonResponse struct {
+	ID     int    `json:"ID"`
+	Name   string `json:"name"`
+	Height int    `json:"height"`
+	Weight int    `json:"weight"`
+
+	Types []struct {
+		Type struct {
+			Name string `json:"name"`
+		} `json:"type"`
+	} `json:"types"`
+
+	LocationAreaEncountersURL string `json:"location_area_encounters"` // URL to retrive location area
+
+	Species struct {
+		URL string `json:"url"` // URL to retrieve pokemon species
+	} `json:"species"`
+
+	Stats []struct {
+		BaseStat int `json:"base_stat"`
+		Stat     struct {
+			Name string `json:"name"`
+		}
+	} `json:"stats"`
+
+	Sprites struct {
+		Versions struct {
+			GenerationI struct {
+				RedBlue struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"red-blue"`
+				Yellow struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"yellow"`
+			} `json:"generation-i"`
+
+			GenerationII struct {
+				Crystal struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"crystal"`
+				Gold struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"gold"`
+				Silver struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"silver"`
+			} `json:"generation-ii"`
+
+			GenerationIII struct {
+				Emerald struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"emerald"`
+				RubySapphire struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"ruby-sapphire"`
+				FireRedLeafGreen struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"firered-leafgreen"`
+			} `json:"generation-iii"`
+
+			GenerationIV struct {
+				DiamondPearl struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"diamond-pearl"`
+				Platinum struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"platinum"`
+				HeartGoldSoulSilver struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"heartgold-soulsilver"`
+			} `json:"generation-iv"`
+
+			GenerationV struct {
+				BlackWhite struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"black-white"`
+			} `json:"generation-v"`
+
+			GenerationVI struct {
+				XY struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"x-y"`
+				OmegaRubyAlphaSapphire struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"omegaruby-alphasapphire"`
+			} `json:"generation-vi"`
+
+			GenerationVII struct {
+				UltraSunUltraMoon struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"ultra-sun-ultra-moon"`
+			} `json:"generation-vii"`
+
+			GenerationVIII struct {
+				SwordShield struct {
+					FrontDefault string `json:"front_default"`
+				} `json:"sword-shield"`
+			} `json:"generation-vii"`
+		} `json:"versions"`
+	} `json:"sprites"`
+}
+
+// PokeAPIChain describes a recursive evolution chain in a PokeAPI evolution-chain response
+type PokeAPIChain struct {
+	EvolvesTo *PokeAPIChain `json:"evolves_to"`
+
+	Species struct {
+		Name string `json:"name"`
+	} `json:"species"`
+}
+
+// PokeAPIEvoChainsResponse describes a evolution chain received by PokeAPI
+type PokeAPIEvoChainsResponse struct {
+	Chain PokeAPIChain `json:"chain"`
+}
+
+// PokeAPILocationAreaEncountersResponse describes a response from Location Area Encounters request
+type PokeAPILocationAreaEncountersResponse struct {
+	Locations []struct {
+		LocationArea struct {
+			Name string `json:"name"`
+		} `json:"location_area"`
+	}
+}
+
+// PokeAPIListPokemonsResponse describes a response from PokeAPI pokemon list request
+type PokeAPIListPokemonsResponse struct {
+	Results []struct {
+		Name string `json:"name"`
+		URL  string `json:"url"` // URL to retrieve details from that Pokemon
+	} `json:"results"`
+}
+
+// PokeAPIPokemonSpeciesResponse describes a response from PokeAPI pokemon species request
+type PokeAPIPokemonSpeciesResponse struct {
+	EvolutionChain struct {
+		URL string `json:"url"` // URL to retrieve evolution chain
+	} `json:"evolution_chain"`
+}

--- a/internal/model/pokemon.go
+++ b/internal/model/pokemon.go
@@ -2,15 +2,15 @@ package model
 
 // Pokemon it's a model that describes a Pokemon.
 type Pokemon struct {
-	ID                     int              `json:"ID"`
-	Name                   string           `json:"name"`
-	Image                  string           `json:"image"`
-	Types                  []string         `json:"types"`
-	LocationAreaEncounters []string         `json:"locationAreaEncounters"`
-	EvolutionChains        [][]string       `json:"evolutionChains"`
-	Weight                 int              `json:"weight"`
-	Height                 int              `json:"height"`
-	BaseStats              PokemonBaseStats `json:"baseStats"`
+	ID                     int               `json:"id"`
+	Name                   string            `json:"name"`
+	Image                  string            `json:"image"`
+	Types                  []string          `json:"types"`
+	LocationAreaEncounters []string          `json:"locationAreaEncounters"`
+	EvolutionChains        [][]string        `json:"evolutionChains"`
+	Weight                 int               `json:"weight"`
+	Height                 int               `json:"height"`
+	BaseStats              *PokemonBaseStats `json:"baseStats"`
 }
 
 // PokemonBaseStats is a model that describes a Pokemon's base stats.
@@ -121,14 +121,14 @@ type PokeAPIPokemonResponse struct {
 				SwordShield struct {
 					FrontDefault string `json:"front_default"`
 				} `json:"sword-shield"`
-			} `json:"generation-vii"`
+			} `json:"generation-viii"`
 		} `json:"versions"`
 	} `json:"sprites"`
 }
 
 // PokeAPIChain describes a recursive evolution chain in a PokeAPI evolution-chain response
 type PokeAPIChain struct {
-	EvolvesTo *PokeAPIChain `json:"evolves_to"`
+	EvolvesTo []PokeAPIChain `json:"evolves_to"`
 
 	Species struct {
 		Name string `json:"name"`

--- a/internal/services/pokeapi.go
+++ b/internal/services/pokeapi.go
@@ -1,0 +1,23 @@
+package services
+
+import (
+	"net/http"
+	"pokemonb2w/internal/model"
+)
+
+// PokeAPIRequester is responsible for sending requests to the PokeAPI and retrieving data
+type PokeAPIRequester interface {
+	ListPokemon(offset int) model.PokeAPIListPokemonsResponse
+	GetPokemon(id int) model.PokeAPIPokemonResponse
+
+	GetPokemonByURL(url string) model.PokeAPIPokemonResponse
+	GetAreaEncountersByURL(url string) model.PokeAPILocationAreaEncountersResponse
+	GetEvolutionChainsByURL(url string) model.PokeAPIEvoChainsResponse
+	GetPokemonSpeciesByURL(url string) model.PokeAPIPokemonSpeciesResponse
+}
+
+type pokeAPIService struct {
+	PokeAPIRequester
+
+	defaultClient http.Client
+}

--- a/internal/services/pokeapi.go
+++ b/internal/services/pokeapi.go
@@ -1,23 +1,159 @@
 package services
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"pokemonb2w/internal/model"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+const (
+	maxIdleConnections    = 10
+	idleConnectionTimeout = 30
+	clientTimeout         = 20
+
+	pokeAPIListPokemonPath = "/pokemon"
+	pokeAPIGetPokemonPath  = "/pokemon/{id}"
 )
 
 // PokeAPIRequester is responsible for sending requests to the PokeAPI and retrieving data
 type PokeAPIRequester interface {
-	ListPokemon(offset int) model.PokeAPIListPokemonsResponse
-	GetPokemon(id int) model.PokeAPIPokemonResponse
+	ListPokemon(offset int) *model.PokeAPIListPokemonsResponse
+	GetPokemon(id int) *model.PokeAPIPokemonResponse
 
-	GetPokemonByURL(url string) model.PokeAPIPokemonResponse
-	GetAreaEncountersByURL(url string) model.PokeAPILocationAreaEncountersResponse
-	GetEvolutionChainsByURL(url string) model.PokeAPIEvoChainsResponse
-	GetPokemonSpeciesByURL(url string) model.PokeAPIPokemonSpeciesResponse
+	GetPokemonByURL(url string) *model.PokeAPIPokemonResponse
+	GetAreaEncountersByURL(url string) *model.PokeAPILocationAreaEncountersResponse
+	GetEvolutionChainsByURL(url string) *model.PokeAPIEvoChainsResponse
+	GetPokemonSpeciesByURL(url string) *model.PokeAPIPokemonSpeciesResponse
 }
 
 type pokeAPIService struct {
 	PokeAPIRequester
 
-	defaultClient http.Client
+	basePath string
+	client   http.Client
+}
+
+// NewPokeAPIRequester returns new PokeAPIRequester
+func NewPokeAPIRequester() PokeAPIRequester {
+	return &pokeAPIService{
+		basePath: viper.GetString("app.pokeApi.basePath"),
+		client: http.Client{
+			Transport: &http.Transport{
+				MaxIdleConns:       maxIdleConnections,
+				IdleConnTimeout:    idleConnectionTimeout * time.Second,
+				DisableCompression: true,
+			},
+			Timeout: clientTimeout * time.Second,
+		},
+	}
+}
+
+func (p *pokeAPIService) ListPokemon(offset int) *model.PokeAPIListPokemonsResponse {
+	var response model.PokeAPIListPokemonsResponse
+
+	// Build request query
+	listPokemonURL := fmt.Sprintf("%s%s", p.basePath, pokeAPIListPokemonPath)
+	req, err := http.NewRequest(http.MethodGet, listPokemonURL, nil)
+	if err != nil {
+		log.Panic("Couldn't create request to the PokeAPI.", err.Error())
+	}
+	q := req.URL.Query()
+	q.Add("offset", strconv.Itoa(offset))
+	req.URL.RawQuery = q.Encode()
+
+	// Perform request
+	p.performRequest(req, &response)
+
+	return &response
+}
+
+func (p *pokeAPIService) GetPokemon(id int) *model.PokeAPIPokemonResponse {
+	// Build request URL
+	getPokemonURL := fmt.Sprintf("%s%s", p.basePath, pokeAPIGetPokemonPath)
+	getPokemonURL = strings.Replace(getPokemonURL, "{id}", strconv.Itoa(id), -1)
+
+	return p.GetPokemonByURL(getPokemonURL)
+}
+
+func (p *pokeAPIService) GetPokemonByURL(url string) *model.PokeAPIPokemonResponse {
+	var response model.PokeAPIPokemonResponse
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Panic("Couldn't create request to the PokeAPI.", err.Error())
+	}
+
+	// Perform request
+	p.performRequest(req, &response)
+
+	return &response
+}
+
+func (p *pokeAPIService) GetAreaEncountersByURL(url string) *model.PokeAPILocationAreaEncountersResponse {
+	var response model.PokeAPILocationAreaEncountersResponse
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Panic("Couldn't create request to the PokeAPI.", err.Error())
+	}
+
+	// Perform request
+	p.performRequest(req, &response.Locations)
+
+	return &response
+}
+
+func (p *pokeAPIService) GetEvolutionChainsByURL(url string) *model.PokeAPIEvoChainsResponse {
+	var response model.PokeAPIEvoChainsResponse
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Panic("Couldn't create request to the PokeAPI.", err.Error())
+	}
+
+	// Perform request
+	p.performRequest(req, &response)
+
+	return &response
+}
+
+func (p *pokeAPIService) GetPokemonSpeciesByURL(url string) *model.PokeAPIPokemonSpeciesResponse {
+	var response model.PokeAPIPokemonSpeciesResponse
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Panic("Couldn't create request to the PokeAPI.", err.Error())
+	}
+
+	// Perform request
+	p.performRequest(req, &response)
+
+	return &response
+}
+
+func (p *pokeAPIService) performRequest(req *http.Request, obj interface{}) {
+	// Perform request
+	res, err := p.client.Do(req)
+	if err != nil {
+		log.Panic("Couldn't perform request to the PokeAPI", err.Error())
+	}
+	defer res.Body.Close()
+
+	// Read response body
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Panic("Couldn't read body from request", err.Error())
+	}
+	err = json.Unmarshal(body, &obj)
+	if err != nil {
+		log.Panic("Couldn't unmarshal response from request", err.Error())
+	}
 }

--- a/static/swagger.json
+++ b/static/swagger.json
@@ -59,9 +59,133 @@
           }
         }
       }
+    },
+    "/pokemon/{id}": {
+      "get": {
+        "description": "Retrieves details about a pokemon by its id.",
+        "tags": [
+          "pokemon"
+        ],
+        "summary": "Retrieves a pokemon by id.",
+        "operationId": "getPokemon",
+        "parameters": [
+          {
+            "type": "integer",
+            "format": "int64",
+            "x-go-name": "ID",
+            "name": "id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/responses/pokemonResponse"
+          },
+          "204": {
+            "description": "No pokemon found.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
+    "Pokemon": {
+      "type": "object",
+      "title": "Pokemon it's a model that describes a Pokemon.",
+      "properties": {
+        "ID": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "baseStats": {
+          "$ref": "#/definitions/PokemonBaseStats"
+        },
+        "evolutionChains": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "x-go-name": "EvolutionChains"
+        },
+        "height": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Height"
+        },
+        "image": {
+          "type": "string",
+          "x-go-name": "Image"
+        },
+        "locationAreaEncounters": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "LocationAreaEncounters"
+        },
+        "name": {
+          "type": "string",
+          "x-go-name": "Name"
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Types"
+        },
+        "weight": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Weight"
+        }
+      },
+      "x-go-package": "pokemonb2w/internal/model"
+    },
+    "PokemonBaseStats": {
+      "type": "object",
+      "title": "PokemonBaseStats is a model that describes a Pokemon's base stats.",
+      "properties": {
+        "attack": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Attack"
+        },
+        "defense": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Defense"
+        },
+        "hp": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "HP"
+        },
+        "special-attack": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "SpecialAttack"
+        },
+        "special-defense": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "SpecialDefense"
+        },
+        "speed": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "Speed"
+        }
+      },
+      "x-go-package": "pokemonb2w/internal/model"
+    },
     "appinfo": {
       "type": "object",
       "title": "AppInfo model.",
@@ -96,6 +220,12 @@
       "description": "An AppInfoResponse response model\n\nThis is used for returning a response the App's info.",
       "schema": {
         "$ref": "#/definitions/appinfo"
+      }
+    },
+    "pokemonResponse": {
+      "description": "PokemonResponse response model\n\nThis is used for returning a response with a pokemon inside the body",
+      "schema": {
+        "$ref": "#/definitions/Pokemon"
       }
     }
   },


### PR DESCRIPTION
Add Endpoint to retrieve pokemon by ID.

- Added PokeServiceAPI that follows the contract:
```golang
type PokeAPIRequester interface {
	ListPokemon(offset int) *model.PokeAPIListPokemonsResponse
	GetPokemon(id int) *model.PokeAPIPokemonResponse

	GetPokemonByURL(url string) *model.PokeAPIPokemonResponse
	GetAreaEncountersByURL(url string) *model.PokeAPILocationAreaEncountersResponse
	GetEvolutionChainsByURL(url string) *model.PokeAPIEvoChainsResponse
	GetPokemonSpeciesByURL(url string) *model.PokeAPIPokemonSpeciesResponse
}
``` 

- Implemented all methods from the service. 
- Implemented a new endpoint in Pokemon controller to retrieve a pokemon by ID (in path).